### PR TITLE
compiler: fix stack mismatch on continue statements nested in switches

### DIFF
--- a/include/ucode/compiler.h
+++ b/include/ucode/compiler.h
@@ -69,6 +69,7 @@ typedef enum {
 typedef struct uc_patchlist {
 	struct uc_patchlist *parent;
 	size_t depth, count, *entries;
+	uc_tokentype_t token;
 } uc_patchlist_t;
 
 typedef struct uc_exprstack {

--- a/tests/custom/04_bugs/39_compiler_switch_continue_mismatch
+++ b/tests/custom/04_bugs/39_compiler_switch_continue_mismatch
@@ -1,0 +1,31 @@
+When compiling continue statements nested in switches, the compiler only
+emitted pop statements for the local variables in the switch body scope,
+but not for the locals in the scope(s) leading up to the containing loop
+body.
+
+Depending on the context, this either led to infinite loops, wrong local
+variable values or segmentation faults.
+
+-- Testcase --
+{%
+	let n = 0;
+
+	while (true) {
+		let x = 1;
+
+		switch (n++) {
+		case 0:
+		case 1:
+			continue;
+		}
+
+		break;
+	}
+
+	print(n, '\n');
+%}
+-- End --
+
+-- Expect stdout --
+3
+-- End --


### PR DESCRIPTION
When compiling continue statements nested in switches, the compiler only
emitted pop statements for the local variables in the switch body scope,
but not for the locals in the scope(s) leading up to the containing loop
body.

Extend the compilers internal patchlist structure to keep track of the
type of scope tied to the patchlist and extend `continue` statement
compilation logic to select the appropriate parent patch list in order
to determine the amount of locals (stack slots) to clear before the
emitted jump instruction.

As a result, the `uc_compiler_backpatch()` implementation can be simplified
somewhat since we do not need to propagate entries to parent lists anymore.

Also add a further regression test case to cover this issue.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>