### PR TITLE
compiler: improve assignment lhs expression checks

### DIFF
--- a/include/ucode/compiler.h
+++ b/include/ucode/compiler.h
@@ -62,8 +62,7 @@ typedef enum {
 
 typedef enum {
 	F_ASSIGNABLE = (1 << 0),
-	F_OPTCHAINING = (1 << 1),
-	F_ALTBLOCKMODE = (1 << 2),
+	F_ALTBLOCKMODE = (1 << 1),
 } uc_exprflag_t;
 
 typedef struct uc_patchlist {

--- a/tests/custom/00_syntax/23_optional_chaining
+++ b/tests/custom/00_syntax/23_optional_chaining
@@ -68,10 +68,10 @@ an assignment or increment/decrement expression.
 
 -- Expect stderr --
 Syntax error: Invalid left-hand side expression for assignment
-In line 2, byte 13:
+In line 2, byte 7:
 
  `    obj?.foo = 1;`
-  Near here -----^
+           ^-- Near here
 
 
 -- End --
@@ -83,7 +83,7 @@ In line 2, byte 13:
 -- End --
 
 -- Expect stderr --
-Syntax error: Invalid increment/decrement operand
+Syntax error: Invalid left-hand side expression for increment/decrement
 In line 2, byte 7:
 
  `    obj?.foo++;`


### PR DESCRIPTION
The existing logic which used the expression stack to check for optional chaining usage in the current expression performed the check against the current scope and all parent scopes, causing assignment expressions embbedded in an outer optional chaining expressions, such as `foo?.[bar.baz = 1]`, to trigger an invalid LHS syntax error during compilation.

Fix this issue by not using the expression stack anymore but by inspecting the patchlist state set up for the current expression parse call to infer whether prior optional chaining operators were compiled for the current property access chain.

Fixes: #307