### PR TITLE
fix: rindex return -1 when needle at the start of str

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -449,7 +449,7 @@ uc_index(uc_vm_t *vm, size_t nargs, bool right)
 							break;
 						}
 					}
-					while (--p != sstr);
+					while (p-- != sstr);
 				}
 				else if (nlen > 0) {
 					p = (const char *)memmem(sstr, slen, nstr, nlen);

--- a/tests/custom/03_stdlib/59_rindex
+++ b/tests/custom/03_stdlib/59_rindex
@@ -20,6 +20,7 @@ Returns the last found index position in all other cases.
 		rindex("foobarfoobarfoobar", "arf"),			// should return 10
 		rindex("test", "hello"),						// should return -1
 		rindex("test", "test"),							// should return 0 (needle = haystack length special case)
+		rindex("hello", "h"),							// should return 0 (needle at haystack start special case)
 		rindex("test", ""),								// should return 4 (zero length needle special case)
 		rindex("", ""),									// should return 0 (zero length special case)
 		rindex("foo\0foo\0foo", "o\0f"),				// should return 6 (binary safe)
@@ -38,6 +39,7 @@ Returns the last found index position in all other cases.
 	1,
 	10,
 	-1,
+	0,
 	0,
 	4,
 	0,


### PR DESCRIPTION
see #327 