### PR TITLE
Revert "nl80211: read all pending event messages"

### DIFF
--- a/lib/nl80211.c
+++ b/lib/nl80211.c
@@ -2722,8 +2722,7 @@ uc_nl_request(uc_vm_t *vm, size_t nargs)
 static void
 uc_nl_listener_cb(struct uloop_fd *fd, unsigned int events)
 {
-	while (nl_recvmsgs(nl80211_conn.evsock, nl80211_conn.evsock_cb) == 0)
-		;
+	nl_recvmsgs(nl80211_conn.evsock, nl80211_conn.evsock_cb);
 }
 
 static uc_value_t *


### PR DESCRIPTION
This reverts commit 387880348c89b5be54ddf13b9543b19266dd02ae. This commit is broken and causes infinite polling on netlink sockets.