### PR TITLE
add include for older kernels

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -77,6 +77,7 @@
 #include "ucode/platform.h"
 
 #if defined(__linux__)
+# include <linux/in6.h>
 # include <linux/if_packet.h>
 # include <linux/filter.h>
 


### PR DESCRIPTION
in6.h is needed for some macros. Seems newer kernels include this implicitly.