### PR TITLE
nl80211: add new attribute "mlo_links" for per link information

### DIFF
--- a/lib/nl80211.c
+++ b/lib/nl80211.c
@@ -908,9 +908,28 @@ static const uc_nl_nested_spec_t nl80211_wiphy_radio_nla = {
 	}
 };
 
+
+static const uc_nl_nested_spec_t nl80211_mlo_link_nla = {
+	.headsize = 0,
+	.nattrs = 11,
+	.attrs = {
+		{ NL80211_ATTR_MLO_LINK_ID, "link_id", DT_U8, 0, NULL },
+		{ NL80211_ATTR_MAC, "mac", DT_LLADDR, 0, NULL },
+		{ NL80211_ATTR_WIPHY_FREQ, "wiphy_freq", DT_U32, 0, NULL },
+		{ NL80211_ATTR_CHANNEL_WIDTH, "channel_width", DT_U32, 0, NULL },
+		{ NL80211_ATTR_CENTER_FREQ1, "center_freq1", DT_U32, 0, NULL },
+		{ NL80211_ATTR_CENTER_FREQ2, "center_freq2", DT_U32, 0, NULL },
+		{ NL80211_ATTR_WIPHY_TX_POWER_LEVEL, "wiphy_tx_power_level", DT_U32, 0, NULL },
+		{ NL80211_ATTR_WIPHY_CHANNEL_TYPE, "wiphy_channel_type", DT_U32, 0, NULL },
+		{ NL80211_ATTR_MLO_LINK_DISABLED, "mlo_link_disabled", DT_FLAG, 0, NULL },
+		{ NL80211_ATTR_MLO_TTLM_DLINK, "mlo_ttlm_dlink", DT_STRING, DF_BINARY, NULL },
+		{ NL80211_ATTR_MLO_TTLM_ULINK, "mlo_ttlm_ulink", DT_STRING, DF_BINARY, NULL },
+	}
+};
+
 static const uc_nl_nested_spec_t nl80211_msg = {
 	.headsize = 0,
-	.nattrs = 130,
+	.nattrs = 131,
 	.attrs = {
 		{ NL80211_ATTR_4ADDR, "4addr", DT_U8, 0, NULL },
 		{ NL80211_ATTR_AIRTIME_WEIGHT, "airtime_weight", DT_U16, 0, NULL },
@@ -1039,6 +1058,7 @@ static const uc_nl_nested_spec_t nl80211_msg = {
 		{ NL80211_ATTR_SUPPORTED_IFTYPES, "supported_iftypes", DT_NESTED, 0, &nl80211_ifcomb_limit_types_nla },
 		{ NL80211_ATTR_SOFTWARE_IFTYPES, "software_iftypes", DT_NESTED, 0, &nl80211_ifcomb_limit_types_nla },
 		{ NL80211_ATTR_MAX_AP_ASSOC_STA, "max_ap_assoc", DT_U16, 0, NULL },
+		{ NL80211_ATTR_MLO_LINKS, "mlo_links", DT_NESTED, DF_MULTIPLE|DF_AUTOIDX, &nl80211_mlo_link_nla },
 		{ NL80211_ATTR_SURVEY_INFO, "survey_info", DT_NESTED, 0, &nl80211_survey_info_nla },
 		{ NL80211_ATTR_WIPHY_RADIOS, "radios", DT_NESTED, DF_MULTIPLE|DF_AUTOIDX, &nl80211_wiphy_radio_nla },
 		{ NL80211_ATTR_VIF_RADIO_MASK, "vif_radio_mask", DT_U32, 0, NULL },


### PR DESCRIPTION
This helps to export MLD information by links, and I just implement it on iwinfo for mld like this:


<details>

```
root@OpenWrt:~# iwinfo
ap-mld0 ESSID: "mld-1"
         Access Point: 00:0a:52:0c:e3:16
         Mode: Master
         Signal: 0 dBm  Link Quality: 70/70
         Bit Rate: unknown
         Encryption: none
         Type: nl80211  HW Mode(s): 802.11be/ax/ac/n
         Hardware: 0x14c3:0x7992 0x14c3:0x7992 [MediaTek MT7992E]
         TX power offset: none
         Channel offset: none
         Supports VAPs: yes  PHY name: phy0
         MLD:
         Link  0:  00:0A:52:0C:E3:16
            Channel: 1 (2.412 GHz)
            Center Channel 1: 1 2: unknown
            Tx-Power: 20 dBm  Noise: -82 dBm
         Link  1:  42:0A:52:0C:E3:16
            Channel: 36 (5.180 GHz)
            Center Channel 1: 42 2: unknown
            Tx-Power: 20 dBm  Noise: -91 dBm

phy0.0-ap0 ESSID: "OpenWrt2g"
         Access Point: 02:0a:52:0c:e3:16
         Mode: Master  Channel: 1 (2.412 GHz)  HT Mode: EHT20
         Center Channel 1: 1 2: unknown
         Tx-Power: 20 dBm  Link Quality: 70/70
         Signal: 0 dBm  Noise: -84 dBm
         Bit Rate: unknown
         Encryption: none
         Type: nl80211  HW Mode(s): 802.11be/ax/n/g/b
         Hardware: 0x14c3:0x7992 0x14c3:0x7992 [MediaTek MT7992E]
         TX power offset: none
         Channel offset: none
         Supports VAPs: yes  PHY name: phy0

phy0.1-ap0 ESSID: "OpenWrt5g"
         Access Point: 00:0a:52:0c:e3:26
         Mode: Master  Channel: 36 (5.180 GHz)  HT Mode: EHT80
         Center Channel 1: 42 2: unknown
         Tx-Power: 20 dBm  Link Quality: 70/70
         Signal: 0 dBm  Noise: -91 dBm
         Bit Rate: unknown
         Encryption: none
         Type: nl80211  HW Mode(s): 802.11be/ax/ac/n
         Hardware: 0x14c3:0x7992 0x14c3:0x7992 [MediaTek MT7992E]
         TX power offset: none
         Channel offset: none
         Supports VAPs: yes  PHY name: phy0
```

</details>

The htmode will be hard to format because of the weak relationships between nl80211 and radios in uci. The former lacks of attributes like "HE|VHT|EHT" and the latter cannot point to the link precisely (Consider to 5G+5G mlo which makes it duplicated.)