### PR TITLE
lib/ubus.c: always permit ubus_rpc_session

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -1487,8 +1487,13 @@ uc_ubus_object_call_args(struct ubus_object *obj, const char *ubus_method_name,
 		}
 
 		/* named argument not found in policy */
-		if (!found)
+		if (!found) {
+			/* allow special ubus_rpc_session argument */
+			if (!strcmp("ubus_rpc_session", (char *)hdr->name) && blob_id(attr) == BLOBMSG_TYPE_STRING)
+				continue;
+
 			goto inval;
+		}
 	}
 
 	*res = blob_array_to_ucv(uuobj->vm, blob_data(msg), blob_len(msg), true);


### PR DESCRIPTION
This is analog to the ucode integration implementation from rpcd and permits using the ubus interface using the web interface.