### PR TITLE
ubus: complete pending requests when disconnecting locally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ if(UBUS_SUPPORT)
   try_compile(HAVE_NEW_UBUS_STATUS_CODES
     ${CMAKE_BINARY_DIR}
     "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test.c")
+  check_function_exists(ubus_flush_requests HAVE_UBUS_FLUSH_REQUESTS)
   check_function_exists(uloop_timeout_remaining64 REMAINING64_FUNCTION_EXISTS)
   check_function_exists(ubus_channel_connect HAVE_CHANNEL_SUPPORT)
   file(WRITE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/test2.c" "
@@ -215,6 +216,9 @@ if(UBUS_SUPPORT)
   endif()
   if(HAVE_NEW_UBUS_STATUS_CODES)
     add_definitions(-DHAVE_NEW_UBUS_STATUS_CODES)
+  endif()
+  if(HAVE_UBUS_FLUSH_REQUESTS)
+    add_definitions(-DHAVE_UBUS_FLUSH_REQUESTS)
   endif()
   if (HAVE_UBUS_NEW_OBJ_CB)
     target_compile_definitions(ubus_lib PUBLIC HAVE_UBUS_NEW_OBJ_CB)

--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -2310,6 +2310,9 @@ uc_ubus_disconnect(uc_vm_t *vm, size_t nargs)
 
 	conn_get(vm, &c);
 
+#ifdef HAVE_UBUS_FLUSH_REQUESTS
+	ubus_flush_requests(&c->ctx);
+#endif
 	ubus_shutdown(&c->ctx);
 	c->ctx.sock.fd = -1;
 	uc_ubus_put_res(&c->res);


### PR DESCRIPTION
libubus only completes pending requests when the socket receives EOF. When explicitly disconnecting, we need to call ubus_flush_requests().