### PR TITLE
io: add ptsname, tcgetattr, tcsetattr, grantpt, unlockpt

### DIFF
--- a/lib/uloop.c
+++ b/lib/uloop.c
@@ -791,7 +791,7 @@ get_fd(uc_vm_t *vm, uc_value_t *val)
  *
  * @function module:uloop#handle
  *
- * @param {number|module:fs.file|module:fs.proc|module:socket.socket} handle
+ * @param {number|module:fs.file|module:fs.proc|module:socket.socket|module:io.handle} handle
  * The file handle (descriptor number, file or socket instance).
  *
  * @param {Function} callback


### PR DESCRIPTION
This commit adds terminal support functions to the io library, thus enabling to use ucode to connect to virtual terminals.

It also adds a small documentation change to uloop since uloop.handle can also acceept io-handles.

Rationale:
I am porting the uxc cli client to ucode. uxc enables users to run OCI images with procd in a container (like docker, but much smaller memory footprint).
The reasoning for porting is to work with OCI registries and images. HTTP handling is too bloated in C, but get's much easier with ucode due to it's memory management and existing binding for uclient.