### PR TITLE
CMakeLists.txt: remove -Werror=format-nonliteral

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,6 @@ if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
     -Wformat
     -Werror=implicit-function-declaration
     -Werror=format-security
-    -Werror=format-nonliteral
   )
 endif()
 


### PR DESCRIPTION
The musl libc fortify source headers are using a nonliteral format string in the sprintf() and snprintf() function. Do not fail in ucode

Not everyone is using the workaround in fortify source headers.