### PR TITLE
lib: fix system() inheriting blocked SIGCHLD mask in child process

### DIFF
--- a/lib.c
+++ b/lib.c
@@ -4042,7 +4042,9 @@ uc_system(uc_vm_t *vm, size_t nargs)
 		goto fail;
 
 	case 0:
-		execvp(arglist[0], (char * const *)arglist);
+		if (tms <= 0 || sigprocmask(SIG_SETMASK, &sigomask, NULL) == 0)
+			execvp(arglist[0], (char * const *)arglist);
+
 		exit(-1);
 
 		break;

--- a/tests/custom/03_stdlib/38_system
+++ b/tests/custom/03_stdlib/38_system
@@ -146,3 +146,29 @@ In line 2, byte 23:
 
 
 -- End --
+
+
+When a timeout is specified, the child process must not inherit the blocked
+SIGCHLD signal mask. If it did, the shell's `wait` builtin would hang, as the
+shell could not receive SIGCHLD notifications for its own subprocesses.
+
+-- Testcase --
+{%
+	// Run a shell that backgrounds a child and waits for it; if SIGCHLD is
+	// blocked in the child, the wait hangs and the timeout kills the process.
+	let rc = system([ '/bin/sh', TESTFILES_PATH + '/testscripts/wait.sh' ], 5000);
+
+	print(rc == 0 ? "wait completed\n" : "wait failed\n");
+%}
+-- End --
+
+-- File testscripts/wait.sh --
+#!/bin/sh
+
+sleep 0 &
+wait
+-- End --
+
+-- Expect stdout --
+wait completed
+-- End --


### PR DESCRIPTION
When a timeout is specified, system() blocks SIGCHLD in the parent to use sigtimedwait(). This blocked signal mask is inherited by the forked child, preventing the spawned shell from receiving SIGCHLD for its own subprocesses, causing zombie processes and hung wait() calls.

Restore the original signal mask in the child before exec().

Fixes: #382