### PR TITLE
lib/socket: strip brackets from IPv6 addresses in addrinfo()

### DIFF
--- a/lib/socket.c
+++ b/lib/socket.c
@@ -2570,9 +2570,11 @@ uc_socket_nameinfo(uc_vm_t *vm, size_t nargs)
 static uc_value_t *
 uc_socket_addrinfo(uc_vm_t *vm, size_t nargs)
 {
+	char hostbuf[sizeof("ffff:ffff:ffff:ffff:ffff:ffff:255.255.255.255%2147483648")];
 	struct addrinfo *ai_hints = NULL, *ai_res;
 	uc_value_t *host, *serv, *hints, *rv;
-	char *servstr;
+	char *hostname, *servstr;
+	size_t hostlen;
 	int ret;
 
 	args_get(vm, nargs, NULL,
@@ -2587,8 +2589,18 @@ uc_socket_addrinfo(uc_vm_t *vm, size_t nargs)
 			return NULL;
 	}
 
+	hostname = ucv_string_get(host);
+	hostlen = ucv_string_length(host);
+
+	if (hostlen > 2 && hostname[0] == '[' && hostname[hostlen - 1] == ']'
+	    && hostlen - 2 < sizeof(hostbuf)) {
+		memcpy(hostbuf, hostname + 1, hostlen - 2);
+		hostbuf[hostlen - 2] = '\0';
+		hostname = hostbuf;
+	}
+
 	servstr = (serv && ucv_type(serv) != UC_STRING) ? ucv_to_string(vm, serv) : NULL;
-	ret = getaddrinfo(ucv_string_get(host),
+	ret = getaddrinfo(hostname,
 		servstr ? servstr : ucv_string_get(serv),
 		ai_hints, &ai_res);
 
@@ -2611,7 +2623,6 @@ uc_socket_addrinfo(uc_vm_t *vm, size_t nargs)
 
 	ok_return(rv);
 }
-
 /**
  * Represents a poll state serving as input parameter and return value type for
  * {@link module:socket#poll|`poll()`}.


### PR DESCRIPTION
## Summary

- Strip URI-style square brackets from IPv6 hostnames in `addrinfo()` before
  passing to `getaddrinfo()`, which does not understand bracket notation.
- Uses the same approach already employed by `uv_to_sockaddr()` for `sockaddr()`.

## Problem

`socket.addrinfo('[::1]', 123)` returns `null` because `getaddrinfo()` receives
the literal string `[::1]` which is not a valid hostname or numeric address.
Meanwhile `socket.sockaddr('[::1]:123')` works correctly because `uv_to_sockaddr()`
already strips brackets.

## Test

```sh
# Before fix: returns empty
ucode -e "print(socket.addrinfo('[::1]', 123), '\n');" -l socket

# After fix: returns address info (same as without brackets)
ucode -e "print(socket.addrinfo('[::1]', 123), '\n');" -l socket
ucode -e "print(socket.addrinfo('::1', 123), '\n');" -l socket

Fixes: #369