### PR TITLE
ubus: avoid unconditional GC after every reply callback

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -2518,8 +2518,9 @@ uc_ubus_handle_reply_common(struct ubus_context *ctx,
 	/* release request object */
 	ucv_put(reqobj);
 
-	/* garbage collect */
-	ucv_gc(vm);
+	/* only garbage collect if significant allocations occurred */
+	if (vm->alloc_refs >= vm->gc_interval)
+		ucv_gc(vm);
 
 	return UBUS_STATUS_OK;
 }


### PR DESCRIPTION
```
The ubus reply handler calls ucv_gc() unconditionally which triggers
a full mark-and-sweep regardless of how many objects were allocated.
For high-frequency callbacks this is disproportionately expensive.

Gate the collection on the same threshold the VM uses: only collect
when alloc_refs reaches gc_interval.
```

I have a ucode app which is very active on ubus. We noticed higher than expected CPU usage and tracked it back to ucv_gc() called from the ubus reply handler.

I'm not positive this is the correct fix but followed the behavior already used in vm.c. It fixes the issue on target and doesn't appear to cause any new issues.