### PR TITLE
main: fix option argument parsing on glibc

### DIFF
--- a/main.c
+++ b/main.c
@@ -33,6 +33,12 @@
 #include "ucode/source.h"
 #include "ucode/program.h"
 
+#ifdef __GLIBC__
+# define POSIXLY_CORRECT_FLAG "+"
+#else
+# define POSIXLY_CORRECT_FLAG ""
+#endif
+
 static FILE *stdin_unused;
 
 static void
@@ -507,7 +513,7 @@ appname(const char *argv0)
 int
 main(int argc, char **argv)
 {
-	const char *optspec = "he:p:tg:ST::RD:F:U:l:L:c::o:s";
+	const char *optspec = POSIXLY_CORRECT_FLAG "he:p:tg:ST::RD:F:U:l:L:c::o:s";
 	bool strip = false, print_result = false;
 	char *interp = "/usr/bin/env ucode";
 	uc_source_t *source = NULL;

--- a/tests/custom/99_bugs/52_ucode_option_arguments
+++ b/tests/custom/99_bugs/52_ucode_option_arguments
@@ -1,0 +1,31 @@
+Test that ucode scripts can receive option arguments via ARGV.
+
+-- Testcase --
+{%
+	// Strip valgrind from UCODE_BIN
+	let ucode = UCODE_BIN;
+	let i = rindex(ucode, ' ');
+	if (i > -1)
+		ucode = substr(ucode, i + 1);
+
+	system([ ucode, TESTFILES_PATH + '/testscripts/hello.uc', '--option', 'otherarg']);
+%}
+-- End --
+
+-- File testscripts/hello.uc --
+#!/usr/bin/ucode
+
+print("This is our test program running!\n");
+print("My arguments are:\n");
+
+for (arg in ARGV) {
+	print(`<${arg}>\n`);
+}
+-- End --
+
+-- Expect stdout --
+This is our test program running!
+My arguments are:
+<--option>
+<otherarg>
+-- End --

--- a/tests/custom/run_tests.uc
+++ b/tests/custom/run_tests.uc
@@ -150,6 +150,7 @@ function run_testcase(num, dir, testcase) {
 		`-T','`,
 		`-L ${shellquote(`${ucode_lib}/*.so`)}`,
 		`-D TESTFILES_PATH=${shellquote(`${fs.realpath(dir)}/files`)}`,
+		`-D UCODE_BIN=${shellquote(`${ucode_bin}`)}`,
 		`${join(' ', map(testcase.args ?? [], shellquote))} -`,
 		`>/dev/fd/${fout.fileno()} 2>/dev/fd/${ferr.fileno()}`
 	]);


### PR DESCRIPTION
Prepend the '+' flag in the getopt() optstring on glibc to stop parsing as soon as the first non-option parameter.  This allows ucode scripts to receive option arguments. Otherwise option arguments are reorder and moved before the script name.

Add test case custom/99_bugs/52_ucode_option_arguments