### PR TITLE
make: improve make (install) on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,35 @@ set(CLI_SOURCES main.c)
 add_executable(ucode ${CLI_SOURCES})
 target_link_libraries(ucode uc_defines libucode)
 
+# Ensure rpath is used on macOS
+set(CMAKE_MACOSX_RPATH ON)
+
+# Automatically include linked library paths in rpath
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+if(APPLE)
+  set_target_properties(libucode PROPERTIES
+    INSTALL_NAME_DIR "@rpath"
+  )
+  set_target_properties(ucode PROPERTIES
+    INSTALL_RPATH "@loader_path/../${CMAKE_INSTALL_LIBDIR}"
+  )
+endif()
+
+if(APPLE AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  execute_process(
+    COMMAND brew --prefix
+    OUTPUT_VARIABLE HOMEBREW_PREFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+
+  if(HOMEBREW_PREFIX AND EXISTS "${HOMEBREW_PREFIX}")
+    message(STATUS "Using Homebrew prefix: ${HOMEBREW_PREFIX}")
+    set(CMAKE_INSTALL_PREFIX "${HOMEBREW_PREFIX}" CACHE PATH "Install path" FORCE)
+  endif()
+endif()
+
 check_function_exists(dlopen DLOPEN_FUNCTION_EXISTS)
 if(NOT DLOPEN_FUNCTION_EXISTS)
   target_link_libraries(libucode dl)


### PR DESCRIPTION
This helps on Darwin when Rosetta is installed.

Rosetta does arm64/x86_64 translation, and can cause architecture detection problems in homebrew environments.

First, check `brew --prefix` to see where the homebrew environment is.

Then set rpath for the built libs. This prevents problems like:

```
dyld[27435]: Library not loaded: @rpath/libucode.0.dylib
  Referenced from: <B09194B4-6903-30AE-B2A8-153C0241E6B2> /opt/homebrew/bin/ucode
  Reason: no LC_RPATH's found
```
where `make install` does:
```
-- Installing: /opt/homebrew/bin/ucode
-- Installing: /opt/homebrew/lib/libucode.0.dylib
-- Installing: /opt/homebrew/lib/libucode.dylib
...
```

This change prevents manual interventions (for arm64) like:

`LDFLAGS += -Wl,-rpath,/opt/homebrew/lib`

or

`install_name_tool -add_rpath /opt/homebrew/lib /opt/homebrew/bin/ucode`