### PR TITLE
Mac ioctl

### DIFF
--- a/lib/fs.c
+++ b/lib/fs.c
@@ -67,6 +67,10 @@
 #define HAS_IOCTL
 #endif
 
+#if defined(__APPLE__)
+#define HAS_MAC_IOCTL
+#endif
+
 #ifdef HAS_IOCTL
 #include <sys/ioctl.h>
 
@@ -75,6 +79,39 @@
 #define IOC_DIR_WRITE	(_IOC_WRITE)
 #define IOC_DIR_RW		(_IOC_READ | _IOC_WRITE)
 
+#define IOCTL_CMD(dir, type, num, size) _IOC((dir), (type), (num), (size))
+#endif
+
+#ifdef HAS_MAC_IOCTL
+#include <sys/ioctl.h>
+#include <sys/ioccom.h>
+
+#define IOC_DIR_NONE	0
+#define IOC_DIR_READ	1
+#define IOC_DIR_WRITE	2
+#define IOC_DIR_RW		(IOC_DIR_READ | IOC_DIR_WRITE)
+
+static unsigned long
+mac_ioctl_cmd(unsigned int dir, unsigned int type, unsigned int num, size_t size)
+{
+	if (num == 0)
+		return type;
+
+	switch (dir) {
+	case IOC_DIR_NONE:
+		return _IO(type, num);
+	case IOC_DIR_READ:
+		return _IOR(type, num, void *);
+	case IOC_DIR_WRITE:
+		return _IOW(type, num, void *);
+	case IOC_DIR_RW:
+		return _IOWR(type, num, void *);
+	default:
+		return 0;
+	}
+}
+
+#define IOCTL_CMD(dir, type, num, size) mac_ioctl_cmd((dir), (type), (num), (size))
 #endif
 
 #include "ucode/module.h"
@@ -977,7 +1014,7 @@ uc_fs_fileno(uc_vm_t *vm, size_t nargs)
 	return uc_fs_fileno_common(vm, nargs, "fs.file");
 }
 
-#ifdef HAS_IOCTL
+#if defined(HAS_IOCTL) || defined(HAS_MAC_IOCTL)
 
 /**
  * Performs an ioctl operation on the file.
@@ -1091,9 +1128,10 @@ uc_fs_ioctl(uc_vm_t *vm, size_t nargs)
 
 	if (ucv_type(num) == UC_NULL) {
 		req = ty;
-	} else {
+	}
+	else {
 		nr = ucv_uint64_get(num);
-		req = _IOC(dir, ty, nr, sz);
+		req = IOCTL_CMD(dir, ty, nr, sz);
 	}
 
 	ret = ioctl(fd, req, buf);
@@ -3117,7 +3155,7 @@ static const uc_function_list_t file_fns[] = {
 	{ "isatty",		uc_fs_isatty },
 	{ "truncate",	uc_fs_truncate },
 	{ "lock",		uc_fs_lock },
-#if defined(__linux__)
+#if defined(__linux__) || defined(__APPLE__)
 	{ "ioctl",		uc_fs_ioctl },
 #endif
 };
@@ -3252,7 +3290,7 @@ void uc_module_init(uc_vm_t *vm, uc_value_t *scope)
 	ucv_object_add(scope, "stdout", uc_resource_new(file_type, stdout));
 	ucv_object_add(scope, "stderr", uc_resource_new(file_type, stderr));
 
-#ifdef HAS_IOCTL
+#if defined(HAS_IOCTL) || defined(HAS_MAC_IOCTL)
 	ADD_CONST(IOC_DIR_NONE);
 	ADD_CONST(IOC_DIR_READ);
 	ADD_CONST(IOC_DIR_WRITE);

--- a/lib/io.c
+++ b/lib/io.c
@@ -63,6 +63,10 @@
 #define HAS_IOCTL
 #endif
 
+#if defined(__APPLE__)
+#define HAS_MAC_IOCTL
+#endif
+
 #ifdef HAS_IOCTL
 #include <sys/ioctl.h>
 
@@ -71,6 +75,38 @@
 #define IOC_DIR_WRITE	(_IOC_WRITE)
 #define IOC_DIR_RW		(_IOC_READ | _IOC_WRITE)
 
+#define IOCTL_CMD(dir, type, num, size) _IOC((dir), (type), (num), (size))
+#endif
+
+#ifdef HAS_MAC_IOCTL
+#include <sys/ioctl.h>
+#include <sys/ioccom.h>
+#define IOC_DIR_NONE	0
+#define IOC_DIR_READ	1
+#define IOC_DIR_WRITE	2
+#define IOC_DIR_RW		(IOC_DIR_READ | IOC_DIR_WRITE)
+
+static unsigned long
+mac_ioctl_cmd(unsigned int dir, unsigned int type, unsigned int num, size_t size)
+{
+	if (num == 0)
+		return type;
+
+	switch (dir) {
+	case IOC_DIR_NONE:
+		return _IO(type, num);
+	case IOC_DIR_READ:
+		return _IOR(type, num, void *);
+	case IOC_DIR_WRITE:
+		return _IOW(type, num, void *);
+	case IOC_DIR_RW:
+		return _IOWR(type, num, void *);
+	default:
+		return 0;
+	}
+}
+
+#define IOCTL_CMD(dir, type, num, size) mac_ioctl_cmd((dir), (type), (num), (size))
 #endif
 
 #include "ucode/module.h"
@@ -902,7 +938,7 @@ uc_io_fcntl(uc_vm_t *vm, size_t nargs)
 	return ucv_int64_new(ret);
 }
 
-#ifdef HAS_IOCTL
+#if defined(HAS_IOCTL) || defined(HAS_MAC_IOCTL)
 
 /**
  * Performs an ioctl operation on the file descriptor.
@@ -1017,9 +1053,10 @@ uc_io_ioctl(uc_vm_t *vm, size_t nargs)
 
 	if (ucv_type(num) == UC_NULL) {
 		req = ty;
-	} else {
+	}
+	else {
 		nr = ucv_uint64_get(num);
-		req = _IOC(dir, ty, nr, sz);
+		req = IOCTL_CMD(dir, ty, nr, sz);
 	}
 
 	ret = ioctl(fd, req, buf);
@@ -1361,7 +1398,7 @@ static const uc_function_list_t io_handle_fns[] = {
 	{ "dup2",		uc_io_dup2 },
 	{ "fileno",		uc_io_fileno },
 	{ "fcntl",		uc_io_fcntl },
-#ifdef HAS_IOCTL
+#if defined(HAS_IOCTL) || defined(HAS_MAC_IOCTL)
 	{ "ioctl",		uc_io_ioctl },
 #endif
 	{ "isatty",		uc_io_isatty },
@@ -1430,7 +1467,7 @@ void uc_module_init(uc_vm_t *vm, uc_value_t *scope)
 	ADD_CONST(TCSADRAIN);
 	ADD_CONST(TCSAFLUSH);
 
-#ifdef HAS_IOCTL
+#if defined(HAS_IOCTL) || defined(HAS_MAC_IOCTL)
 	ADD_CONST(IOC_DIR_NONE);
 	ADD_CONST(IOC_DIR_READ);
 	ADD_CONST(IOC_DIR_WRITE);


### PR DESCRIPTION
Provide ioctl on mac.

macOS/Darwin has ioctl, but the mappings are a bit different. 

Verified using:
```js
import * as io from 'io';
import * as struct from 'struct';

let handle = io.open('/dev/tty', io.O_RDWR);
if (!handle) {
	print('open failed:', io.error(), '\n');
	return;
}

let req = 0x40087468;   // macOS TIOCGWINSZ raw request
let buf = handle.ioctl(io.IOC_DIR_READ, req, 0, 8);
if (!buf) {
	print('ioctl failed:', io.error(), '\n');
}

/*
struct winsize {
	unsigned short ws_row;
	unsigned short ws_col;
	unsigned short ws_xpixel;
	unsigned short ws_ypixel;
};
*/
let arr = struct.unpack('HHHH', buf);

print('winsize:\n');
print('  rows:   ', arr[0], '\n');
print('  cols:   ', arr[1], '\n');
print('  xpixel: ', arr[2], '\n');
print('  ypixel: ', arr[3], '\n');

handle.close();

```

result:
```
winsize:
  rows:   71
  cols:   183
  xpixel: 2562
  ypixel: 1846
```