### PR TITLE
Various leak/cycle fixes

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -673,8 +673,17 @@ static void
 uc_ubus_put_res(uc_value_t **rp)
 {
 	uc_value_t *res = *rp;
+	uc_resource_ext_t *ext;
 
 	*rp = NULL;
+
+	if (!res)
+		return;
+
+	ext = (uc_resource_ext_t *)res;
+	for (size_t i = 0; i < ext->uvcount; i++)
+		ucv_resource_value_set(res, i, NULL);
+
 	ucv_resource_persistent_set(res, false);
 	ucv_put(res);
 }

--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -3608,12 +3608,15 @@ static void
 uc_ubus_channel_disconnect_cb(struct ubus_context *ctx)
 {
 	uc_ubus_connection_t *c = container_of(ctx, uc_ubus_connection_t, ctx);
-	uc_value_t *func;
+	uc_value_t *res, *func;
 
-	func = ucv_resource_value_get(c->res, CONN_RES_DISCONNECT_CB);
+	/* pin ref across user callback to guard against re-entrant disconnect() */
+	res = ucv_get(c->res);
+
+	func = ucv_resource_value_get(res, CONN_RES_DISCONNECT_CB);
 
 	if (ucv_is_callable(func)) {
-		uc_vm_stack_push(c->vm, ucv_get(c->res));
+		uc_vm_stack_push(c->vm, ucv_get(res));
 		uc_vm_stack_push(c->vm, ucv_get(func));
 
 		if (uc_ubus_vm_call(c->vm, true, 0))
@@ -3632,6 +3635,7 @@ uc_ubus_channel_disconnect_cb(struct ubus_context *ctx)
 	}
 
 	uc_ubus_put_res(&c->res);
+	ucv_put(res);
 }
 
 static uc_value_t *

--- a/lib/uloop.c
+++ b/lib/uloop.c
@@ -106,11 +106,16 @@ static void
 uc_uloop_cb_free(uc_uloop_cb_t *cb)
 {
 	uc_value_t *obj = cb->obj;
+	uc_resource_ext_t *ext;
 
 	if (!obj)
 		return;
 
 	cb->obj = NULL;
+
+	ext = (uc_resource_ext_t *)obj;
+	for (size_t i = 0; i < ext->uvcount; i++)
+		ucv_resource_value_set(obj, i, NULL);
 
 	ucv_resource_persistent_set(obj, false);
 	ucv_put(obj);

--- a/lib/uloop.c
+++ b/lib/uloop.c
@@ -1441,6 +1441,7 @@ uloop_fd_close(struct uloop_fd *fd) {
 	if (fd->fd == -1)
 		return;
 
+	uloop_fd_delete(fd);
 	close(fd->fd);
 	fd->fd = -1;
 }

--- a/types.c
+++ b/types.c
@@ -1485,12 +1485,14 @@ ucv_prototype_set(uc_value_t *uv, uc_value_t *proto)
 	switch (ucv_type(uv)) {
 	case UC_ARRAY:
 		array = (uc_array_t *)uv;
+		ucv_put(array->proto);
 		array->proto = proto;
 
 		return true;
 
 	case UC_OBJECT:
 		object = (uc_object_t *)uv;
+		ucv_put(object->proto);
 		object->proto = proto;
 
 		return true;


### PR DESCRIPTION
Break potential reference cycles by clearing resource held values.
Fix fd leak on uloop tasks
Fix potential use-after-free on re-entrant ubus channel disconnect calls
Fix refcount leak on setting prototypes