### PR TITLE
ubus: fix reply leak in deferred data callback

### DIFF
--- a/lib/ubus.c
+++ b/lib/ubus.c
@@ -1171,7 +1171,7 @@ uc_ubus_call_data_user_cb(struct ubus_request *req, int type, struct blob_attr *
 
 		uc_vm_stack_push(vm, ucv_get(defer->res));
 		uc_vm_stack_push(vm, ucv_get(func));
-		uc_vm_stack_push(vm, ucv_get(reply));
+		uc_vm_stack_push(vm, reply);
 
 		if (uc_ubus_vm_call(vm, true, 1))
 			ucv_put(uc_vm_stack_pop(vm));


### PR DESCRIPTION
blob_array_to_ucv() returns the reply with a reference count of 1 owned by uc_ubus_call_data_user_cb(). Pushing it onto the VM stack with an extra ucv_get() leaves that owning reference unreleased after the callback returns and leaks the entire reply object on every data callback invocation.