### PR TITLE
Support rethrowing exceptions

### DIFF
--- a/include/ucode/types.h
+++ b/include/ucode/types.h
@@ -305,8 +305,11 @@ typedef enum {
 	EXCEPTION_TYPE,
 	EXCEPTION_REFERENCE,
 	EXCEPTION_USER,
-	EXCEPTION_EXIT
+	EXCEPTION_EXIT,
+	EXCEPTION_MAX
 } uc_exception_type_t;
+
+extern const char *exception_type_strings[];
 
 typedef struct {
 	uc_exception_type_t type;

--- a/lib.c
+++ b/lib.c
@@ -738,30 +738,103 @@ uc_chr(uc_vm_t *vm, size_t nargs)
 	return rv;
 }
 
+static uc_exception_type_t
+check_exception_object(uc_value_t *obj)
+{
+	uc_value_t *trace, *entry, *type;
+	uc_exception_type_t i;
+	const char *typestr;
+	size_t len;
+
+	if (ucv_type(obj) != UC_OBJECT)
+		return EXCEPTION_NONE;
+
+	trace = ucv_object_get(obj, "stacktrace", NULL);
+
+	if (ucv_type(trace) != UC_ARRAY)
+		return EXCEPTION_NONE;
+
+	len = ucv_array_length(trace);
+
+	if (len == 0)
+		return EXCEPTION_NONE;
+
+	entry = ucv_array_get(trace, 0);
+
+	if (ucv_type(entry) != UC_OBJECT || ucv_object_get(entry, "line", NULL) == NULL)
+		return EXCEPTION_NONE;
+
+	type = ucv_object_get(obj, "type", NULL);
+
+	if (ucv_type(type) != UC_STRING)
+		return EXCEPTION_USER;
+
+	typestr = ucv_string_get(type);
+
+	for (i = EXCEPTION_SYNTAX; i < EXCEPTION_MAX; i++)
+		if (exception_type_strings[i] && strcmp(typestr, exception_type_strings[i]) == 0)
+			return i;
+
+	return EXCEPTION_USER;
+}
+
 /**
  * Raise an exception with the given message and abort execution.
  *
+ * When passed an exception object (an object with `message` and/or
+ * `stacktrace` properties matching the shape of a caught exception),
+ * `die()` preserves the original message and stacktrace instead of
+ * creating new ones — enabling clean re-throw semantics.
+ *
  * @function module:core#die
  *
- * @param {string} msg
- * The error message.
+ * @param {string|Object} msg
+ * The error message, or an exception-like object with `message` and
+ * `stacktrace` properties.
  *
  * @throws {Error}
  * The error with the given message.
  *
  * @example
  * die(msg);
+ *
+ * @example
+ * try {
+ *     inner();
+ * } catch (e) {
+ *     die(e);  // re-throw preserving original message and stacktrace
+ * }
  */
 static uc_value_t *
 uc_die(uc_vm_t *vm, size_t nargs)
 {
-	uc_value_t *msg = uc_fn_arg(0);
+	uc_value_t *arg = uc_fn_arg(0);
+	uc_exception_type_t etype;
 	bool freeable = false;
 	char *s;
 
-	s = msg ? uc_cast_string(vm, &msg, &freeable) : "Died";
+	/* If arg is an exception object with a valid stacktrace, use it
+	 * directly to avoid the cost of capturing a new one. */
+	etype = check_exception_object(arg);
 
-	uc_vm_raise_exception(vm, EXCEPTION_USER, "%s", s);
+	if (etype != EXCEPTION_NONE)
+	{
+		uc_value_t *msg = ucv_object_get(arg, "message", NULL);
+
+		s = msg ? uc_cast_string(vm, &msg, &freeable) : "Died";
+
+		vm->exception.type = etype;
+		free(vm->exception.message);
+		vm->exception.message = strdup(s);
+
+		ucv_put(vm->exception.stacktrace);
+		vm->exception.stacktrace = ucv_get(ucv_object_get(arg, "stacktrace", NULL));
+	}
+	else
+	{
+		s = arg ? uc_cast_string(vm, &arg, &freeable) : "Died";
+		uc_vm_raise_exception(vm, EXCEPTION_USER, "%s", s);
+	}
 
 	if (freeable)
 		free(s);

--- a/tests/custom/03_stdlib/43_regexp
+++ b/tests/custom/03_stdlib/43_regexp
@@ -75,11 +75,11 @@ Passing an uncompilable regexp throws an exception.
 -- End --
 
 -- Expect stderr --
-Compile error
-In line 10, byte 8:
+Syntax error: Compile error
+In line 4, byte 16:
 
- `        die(e);`
-  Near here ---^
+ `        regexp("foo(");`
+  Near here -----------^
 
 
 -- End --

--- a/vm.c
+++ b/vm.c
@@ -80,7 +80,7 @@ static const int8_t insn_operand_bytes[__I_MAX] = {
 	[I_DYNLOAD] = 4
 };
 
-static const char *exception_type_strings[] = {
+const char *exception_type_strings[] = {
 	[EXCEPTION_SYNTAX] = "Syntax error",
 	[EXCEPTION_RUNTIME] = "Runtime error",
 	[EXCEPTION_TYPE] = "Type error",


### PR DESCRIPTION
Extend the `die()` implementation to re-throw arguments with exception object shape verbatim.